### PR TITLE
add gateway field

### DIFF
--- a/models/base/shopify_orders.sql
+++ b/models/base/shopify_orders.sql
@@ -31,6 +31,7 @@ select
   name,
   note,
   tags,
+  gateway,
 
   -- attribution
   browser_ip,


### PR DESCRIPTION
Adds the `gateway` field to the `shopify_orders` model.

Confirmed that this is provided by Stitch: https://www.stitchdata.com/docs/integrations/saas/shopify#orders-attributes